### PR TITLE
Fix PokemonControllerTest.java

### DIFF
--- a/application/src/test/java/com/example/pokemonalea/application/service/PokemonControllerTest.java
+++ b/application/src/test/java/com/example/pokemonalea/application/service/PokemonControllerTest.java
@@ -156,12 +156,13 @@ class PokemonControllerTest {
 
         // then
         assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
-        assertThat(response.getContentAsString()).isEqualTo(
-                objectMapper.writeValueAsString(controllerTop)
-        );
-        assertThat(response.getContentAsString()).isEqualTo(
-                objectMapper.writeValueAsString(top5Height)
-        );
+
+        String actualResponseContent = response.getContentAsString();
+        String expectedControllerTopJSON = objectMapper.writeValueAsString(controllerTop);
+        JSONAssert.assertEquals(expectedControllerTopJSON, actualResponseContent, false);
+
+        String expectedTop5HeightJSON = objectMapper.writeValueAsString(top5Height);
+        JSONAssert.assertEquals(expectedTop5HeightJSON, actualResponseContent, false);
     }
 
     @Test

--- a/application/src/test/java/com/example/pokemonalea/application/service/PokemonControllerTest.java
+++ b/application/src/test/java/com/example/pokemonalea/application/service/PokemonControllerTest.java
@@ -210,12 +210,14 @@ class PokemonControllerTest {
 
         // then
         assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
-        assertThat(response.getContentAsString()).isEqualTo(
-                objectMapper.writeValueAsString(controllerAll)
-        );
-        assertThat(response.getContentAsString()).isEqualTo(
-                objectMapper.writeValueAsString(allPokemon)
-        );
+
+        String actualControllerAllJSON = response.getContentAsString();
+        String expectedControllerAllJSON = objectMapper.writeValueAsString(controllerAll);
+        JSONAssert.assertEquals(expectedControllerAllJSON, actualControllerAllJSON, false);
+
+        String actualAllPokemonJSON1 = response.getContentAsString();
+        String expectedAllPokemonJSON1 = objectMapper.writeValueAsString(allPokemon);
+        JSONAssert.assertEquals(expectedAllPokemonJSON1, actualAllPokemonJSON1, false);
     }
 
     @Test

--- a/application/src/test/java/com/example/pokemonalea/application/service/PokemonControllerTest.java
+++ b/application/src/test/java/com/example/pokemonalea/application/service/PokemonControllerTest.java
@@ -244,12 +244,14 @@ class PokemonControllerTest {
 
         // then
         assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
-        assertThat(response.getContentAsString()).isEqualTo(
-                objectMapper.writeValueAsString(controllerModel)
-        );
-        assertThat(response.getContentAsString()).isEqualTo(
-                objectMapper.writeValueAsString(pokemonModel)
-        );
+        
+        String actualControllerModelJSON = response.getContentAsString();
+        String expectedControllerModelJSON = objectMapper.writeValueAsString(controllerModel);
+        JSONAssert.assertEquals(expectedControllerModelJSON, actualControllerModelJSON, false);
+
+        String actualPokemonModelJSON = response.getContentAsString();
+        String expectedPokemonModelJSON = objectMapper.writeValueAsString(pokemonModel);
+        JSONAssert.assertEquals(expectedPokemonModelJSON, actualPokemonModelJSON, false);
     }
 
     @Test

--- a/application/src/test/java/com/example/pokemonalea/application/service/PokemonControllerTest.java
+++ b/application/src/test/java/com/example/pokemonalea/application/service/PokemonControllerTest.java
@@ -128,12 +128,13 @@ class PokemonControllerTest {
 
         // then
         assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
-        assertThat(response.getContentAsString()).isEqualTo(
-                objectMapper.writeValueAsString(controllerTop)
-        );
-        assertThat(response.getContentAsString()).isEqualTo(
-                objectMapper.writeValueAsString(top5Weight)
-        );
+        
+        String actualResponseContent = response.getContentAsString();
+        String expectedControllerTopJSON = objectMapper.writeValueAsString(controllerTop);
+        JSONAssert.assertEquals(expectedControllerTopJSON, actualResponseContent, false);
+        
+        String expectedTop5WeightJSON = objectMapper.writeValueAsString(top5Weight);
+        JSONAssert.assertEquals(expectedTop5WeightJSON, actualResponseContent, false);
     }
 
     @Test

--- a/application/src/test/java/com/example/pokemonalea/application/service/PokemonControllerTest.java
+++ b/application/src/test/java/com/example/pokemonalea/application/service/PokemonControllerTest.java
@@ -184,12 +184,13 @@ class PokemonControllerTest {
 
         // then
         assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
-        assertThat(response.getContentAsString()).isEqualTo(
-                objectMapper.writeValueAsString(controllerTop)
-        );
-        assertThat(response.getContentAsString()).isEqualTo(
-                objectMapper.writeValueAsString(top5BaseExperience)
-        );
+
+        String actualResponseContent = response.getContentAsString();
+        String expectedControllerTopJSON = objectMapper.writeValueAsString(controllerTop);
+        JSONAssert.assertEquals(expectedControllerTopJSON, actualResponseContent, false);
+
+        String expectedTop5BaseExperienceJSON = objectMapper.writeValueAsString(top5BaseExperience);
+        JSONAssert.assertEquals(expectedTop5BaseExperienceJSON, actualResponseContent, false);
     }
 
     @Test
@@ -244,7 +245,7 @@ class PokemonControllerTest {
 
         // then
         assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
-        
+
         String actualControllerModelJSON = response.getContentAsString();
         String expectedControllerModelJSON = objectMapper.writeValueAsString(controllerModel);
         JSONAssert.assertEquals(expectedControllerModelJSON, actualControllerModelJSON, false);

--- a/application/src/test/java/com/example/pokemonalea/application/service/PokemonControllerTest.java
+++ b/application/src/test/java/com/example/pokemonalea/application/service/PokemonControllerTest.java
@@ -78,12 +78,14 @@ class PokemonControllerTest {
 
         // then
         assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
-        assertThat(response.getContentAsString()).isEqualTo(
-                objectMapper.writeValueAsString(controllerModel)
-        );
-        assertThat(response.getContentAsString()).isEqualTo(
-                objectMapper.writeValueAsString(pokemonModel)
-        );
+
+        String actualControllerModelJSON = response.getContentAsString();
+        String expectedControllerModelJSON = objectMapper.writeValueAsString(controllerModel);
+        JSONAssert.assertEquals(expectedControllerModelJSON, actualControllerModelJSON, false); 
+
+        String actualPokemonModelJSON = response.getContentAsString();
+        String expectedPokemonModelJSON = objectMapper.writeValueAsString(pokemonModel);
+        JSONAssert.assertEquals(expectedPokemonModelJSON, actualPokemonModelJSON, false);
     }
 
     @Test

--- a/application/src/test/java/com/example/pokemonalea/application/service/PokemonControllerTest.java
+++ b/application/src/test/java/com/example/pokemonalea/application/service/PokemonControllerTest.java
@@ -17,6 +17,7 @@ import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.validation.Validator;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -287,12 +288,14 @@ class PokemonControllerTest {
 
         // then
         assertThat(response.getStatus()).isEqualTo(HttpStatus.CREATED.value());
-        assertThat(response.getContentAsString()).isEqualTo(
-                objectMapper.writeValueAsString(controllerModel)
-        );
-        assertThat(response.getContentAsString()).isEqualTo(
-                objectMapper.writeValueAsString(pokemonModel)
-        );
+
+        String actualJSON = response.getContentAsString();
+        String expectedJSON = objectMapper.writeValueAsString(controllerModel);
+        JSONAssert.assertEquals(expectedJSON, actualJSON, false);
+
+        String actualJSON1 = response.getContentAsString();
+        String expectedJSON1 = objectMapper.writeValueAsString(pokemonModel);
+        JSONAssert.assertEquals(expectedJSON1, actualJSON1, false);
     }
 
     private List<PokemonModel> createTopOrderByWeight() {


### PR DESCRIPTION
# Problem Description:
The project had seven failing tests due to inconsistent field ordering during JSON string comparison.
Here are the seven methods:
```
PokemonControllerTest.getAllPokemon
PokemonControllerTest.getPokemonByIdWhenExists
PokemonControllerTest.getRandomPokemon
PokemonControllerTest.getTopBaseExperiencePokemon
PokemonControllerTest.getTopHeightPokemon
PokemonControllerTest.getTopWeightPokemon
```

# Cause Analysis:
The fields in a JSON object are unordered when serialized, which led to logically equivalent JSON objects being unequal in string form due to differing field orders.
For example, the original code write:
```
        assertThat(response.getContentAsString()).isEqualTo(
                objectMapper.writeValueAsString(controllerModel)
        );
        assertThat(response.getContentAsString()).isEqualTo(
                objectMapper.writeValueAsString(pokemonModel)
        );
```
This would fail because the JSON objects do not guarantee the order of their values. So there will be a potential error:
```
PokemonControllerTest > getPokemonByIdWhenExists() FAILED
    org.opentest4j.AssertionFailedError: 
    Expecting:
     <"{"id":1,"height":1,"weight":1,"name":"ALEA","baseExperience":1}">
    to be equal to:
     <"{"height":1,"name":"ALEA","baseExperience":1,"weight":1,"id":1}">
    but was not.
```
We can see from the error message that although all the values in the two objects are the same, they are in a different order, which causes the comparison to fail.

# Solution Applied:
We utilized the JSONassert library to compare JSON content instead of direct string comparison. This approach ensured the stability of our tests, making them unaffected by field order.

Fix example:
```        
        String actualControllerModelJSON = response.getContentAsString();
        String expectedControllerModelJSON = objectMapper.writeValueAsString(controllerModel);
        JSONAssert.assertEquals(expectedControllerModelJSON, actualControllerModelJSON, false); 

        String actualPokemonModelJSON = response.getContentAsString();
        String expectedPokemonModelJSON = objectMapper.writeValueAsString(pokemonModel);
        JSONAssert.assertEquals(expectedPokemonModelJSON, actualPokemonModelJSON, false);
```
